### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ cd snip
 ```
 
 To view client/server installation instructions, open the respective directories. 
-> [client](/tree/master/client#snip-website) | [server](/tree/master/server#snip-website)
+> [client](/client#snip-website) | [server](/server#snip-api)
 
 Note: You will need at least NodeJS 10.18.1+, VSCode 1.44+, Yarn 1.17.3+ and MongoDB 3+. You will also need to configure .env variables before launching.
 


### PR DESCRIPTION
Updated some links in the README files so that they pointed to real locations.

The links to client and server documentation in the main README we landing on 404 pages. This PR fixes them to point at where (I think) they were meant to land.

**Status**

- [x] Code changes have been tested against eslint, or there are no code changes
- [x] I know how to update typings and have done so, or typings don't need updating

**Semantic versioning classification:**

- [ ] This PR changes the library's interface (methods or parameters added)
  - [ ] This PR includes breaking changes (methods removed or renamed, parameters moved or removed)
- [x] This PR **only** includes non-code changes, like changes to documentation, README, etc.